### PR TITLE
Add '.js' to 'browser' field file names.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "git://github.com/bevacqua/poser.git"
   },
   "browser": {
-    "./src/node": "./src/browser"
+    "./src/node.js": "./src/browser.js"
   },
   "devDependencies": {
     "browserify": "^4.1.3",

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,11 +1,10 @@
 'use strict';
 
 var d = global.document;
-var frames = global.frames;
 
 function poser (type) {
   var iframe = d.createElement('iframe');
-  
+
   iframe.style.display = 'none';
   d.body.appendChild(iframe);
 


### PR DESCRIPTION
From some trial and error, it seems like files in the ['browser' package.json field](https://github.com/substack/node-browserify#browser-field) need to include the file extension to work properly. Before changing this, I always got the output from `./src/node.js`; now it seems like it working.

Also, I removed the `var frames = global.frames` line from `./src/browser.js`, as there is no reference to a `frames` variable.
